### PR TITLE
Add cancer_annotation_db workflow input

### DIFF
--- a/lib/perl/Genome/Model/ClinSeq.pm
+++ b/lib/perl/Genome/Model/ClinSeq.pm
@@ -1176,6 +1176,11 @@ sub cufflinks_differential_expression_op {
         destination          => $cufflinks_differential_expression_op,
         destination_property => 'outdir',
     );
+    $workflow->connect_input(
+        input_property       => 'cancer_annotation_db',
+        destination          => $cufflinks_differential_expression_op,
+        destination_property => 'cancer_annotation_db',
+    );
     $workflow->connect_output(
         output_property => 'cufflinks_differential_expression_result',
         source          => $cufflinks_differential_expression_op,


### PR DESCRIPTION
When a normal RNA-seq is defined, then differential expression steps are added to the workflow.  The cancer_annotation_db is a required input and had to be linked.
